### PR TITLE
Add PEP517 build configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 venv/
 __pycache__
 secret.py
+dist/
+*.egg-info/
+build/

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,3 @@
+__all__ = [
+  "wechat", "alipay_web", "alipay_mobile", "boc_credit_card", "boc_debit_card", "cmb_debit_card"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,36 @@
+[metadata]
+name = china_bean_importers
+version = 0.0.1
+description = Beancount importers for Chinese users
+
+[options]
+package_dir =
+    china_bean_importers = .
+    china_bean_importers.alipay_mobile = ./alipay_mobile
+    china_bean_importers.alipay_web = ./alipay_web
+    china_bean_importers.boc_credit_card = ./boc_credit_card
+    china_bean_importers.boc_debit_card = ./boc_debit_card
+    china_bean_importers.ccb_debit_card = ./ccb_debit_card
+    china_bean_importers.cmb_debit_card = ./cmb_debit_card
+    china_bean_importers.cmbc_credit_card = ./cmbc_credit_card
+    china_bean_importers.cmbc_debit_card = ./cmbc_debit_card
+    china_bean_importers.thu_ecard = ./thu_ecard
+    china_bean_importers.wechat = ./wechat
+
+packages =
+    china_bean_importers
+    china_bean_importers.alipay_mobile
+    china_bean_importers.alipay_web
+    china_bean_importers.boc_credit_card
+    china_bean_importers.boc_debit_card
+    china_bean_importers.ccb_debit_card
+    china_bean_importers.cmb_debit_card
+    china_bean_importers.cmbc_credit_card
+    china_bean_importers.cmbc_debit_card
+    china_bean_importers.thu_ecard
+    china_bean_importers.wechat
+
+install_requires =
+  pymupdf
+  beancount
+  BeautifulSoup4


### PR DESCRIPTION
This modification tries to keep the filesystem structure unchanged, so it won't affect existing users who is using submodule-based installation.