### PR TITLE
Fix: Parse BOC credit bills

### DIFF
--- a/boc_credit_card/__init__.py
+++ b/boc_credit_card/__init__.py
@@ -58,6 +58,8 @@ class Importer(importer.ImporterProtocol):
                     parts = content.split("\n")
                     if len(parts) == 4:
                         return parse(parts[1])
+                    elif len(parts) == 3 || len(parts) == 2:
+                        return parse(parts[0])
                     else:
                         break
         elif self.type == "email":

--- a/boc_credit_card/__init__.py
+++ b/boc_credit_card/__init__.py
@@ -58,7 +58,7 @@ class Importer(importer.ImporterProtocol):
                     parts = content.split("\n")
                     if len(parts) == 4:
                         return parse(parts[1])
-                    elif len(parts) == 3 || len(parts) == 2:
+                    elif len(parts) == 3 or len(parts) == 2:
                         return parse(parts[0])
                     else:
                         break


### PR DESCRIPTION
The following two special PDF bill format can be handled:
![image](https://github.com/user-attachments/assets/5a6ca623-5c97-4a45-ac67-4655087a8d26)

![image](https://github.com/user-attachments/assets/f7fd9859-fa1c-49ab-be10-f9ae81bb6237)
