### PR TITLE
fix(wechat): fix money flow direction on withdraw

### DIFF
--- a/wechat/__init__.py
+++ b/wechat/__init__.py
@@ -72,6 +72,8 @@ class Importer(CsvImporter):
                     direction = "支出"
                 if direction == "/" and "零钱" in type:
                     direction = "收入"
+                    if type == "零钱提现":
+                        direction = "支出"
                 if (i := narration.find("付款方留言")) != -1:
                     narration = f"{narration[:i]};{narration[i:]}"
 


### PR DESCRIPTION
目前对于微信余额提现到银行卡的交易，生成结果的资金流方向是相反的（银行卡 -> 微信）。

示例：

```csv
----------------------微信支付账单明细列表--------------------,,,,,,,,
交易时间,交易类型,交易对方,商品,收/支,金额(元),支付方式,当前状态,交易单号,商户单号,备注
2024-10-24 07:07:07,零钱提现,中国银行(4321),"/",/,¥346.46,中国银行储蓄卡(4321),提现已到账,4321   ,/  ,"服务费¥0.00"
```

修改前（银行卡到微信钱包）：
```
2024-10-24 * "中国银行(4321)" ""
  payment_method: "微信支付"
  imported_category: "零钱提现"
  serial: "4321"
  time: "07:07:07"
  Assets:WeChat              346.46 CNY
  Assets:Card:BoC:4321
```

修改后（微信钱包到银行卡）：
```
2024-10-24 * "中国银行(4321)" ""
  payment_method: "微信支付"
  imported_category: "零钱提现"
  serial: "4321"
  time: "07:07:07"
  Assets:WeChat              -346.46 CNY
  Assets:Card:BoC:4321
```