### PR TITLE
Refine BoC credit card identification for reissued ones

### DIFF
--- a/china_bean_importers/boc_credit_card/__init__.py
+++ b/china_bean_importers/boc_credit_card/__init__.py
@@ -17,11 +17,16 @@ class Importer(importer.ImporterProtocol):
     def identify(self, file):
         if file.name.upper().endswith(".PDF"):
             self.type = "pdf"
-            if "中国银行信用卡" in file.name:
-                import fitz
 
+            import fitz
+            if "中国银行信用卡" in file.name:
                 self.doc = fitz.open(file.name)
                 return True
+            elif "中国银行" in file.name:
+                doc = fitz.open(file.name)
+                if "信用卡账单" in doc[0].get_text():
+                    self.doc = doc
+                    return True
             return False
         elif file.name.upper().endswith(".EML"):
             self.type = "email"


### PR DESCRIPTION
Example of reissued BoC credit card bill:

<img width="1195" height="168" alt="image" src="https://github.com/user-attachments/assets/d172e3df-e3d6-4357-bd31-6d16bb375f25" />

The content is identical. We only need to handle the different filename.