### PR TITLE
boc_debit_card: Skip refunds if in blacklist

### DIFF
--- a/china_bean_importers/boc_debit_card/__init__.py
+++ b/china_bean_importers/boc_debit_card/__init__.py
@@ -39,6 +39,9 @@ def gen_txn(config, file, parts, lineno, flag, card_acc, real_name):
         if units1 < amount.Amount(D(0), currency_code):
             print(f"Expense skipped", file=sys.stderr)
             return None
+        elif "退款" in parts[5]:
+            print(f"Refund skipped", file=sys.stderr)
+            return None
         else:
             print(f"Income kept in record", file=sys.stderr)
 


### PR DESCRIPTION
Currently, refunds are tracked as incomes during blacklist check, and thus kept.

However, refunds also appears in Alipay and WeChat's bills, so they are duplicated.